### PR TITLE
Make logger text argument optional

### DIFF
--- a/lib/logger.py
+++ b/lib/logger.py
@@ -13,7 +13,7 @@ class Logger(object):
             Logger.__instance.last_logged_line = None
         return Logger.__instance
 
-    def log(self, text, end='\n', flush=False):
+    def log(self, text="", end='\n', flush=False):
         if (not text == self.last_logged_line) or (end == ''):
             print(text, end=end, flush=flush)
             self.last_logged_line = text


### PR DESCRIPTION
The code contains logger.log() which fails as log() expects a non-empty
text argument now. Make it print an empty line by default if we do not
pass it any arguments.

This fixes exposure-notification-ble-python/issues/1.